### PR TITLE
demo/main.py에 pdf to txt 모듈 추가

### DIFF
--- a/Demo/main.py
+++ b/Demo/main.py
@@ -5,6 +5,7 @@ from classification import process_file_by_type
 from classification import FileClassifier
 from database import BidNotice, get_db, init_db
 from HwpToTxt.hwp_olefile_converter import HwpOleFileConverter
+from PdfToTxt.pdf_converter import PdfFileConverter
 
 app = FastAPI(
     title="File to Txt Converter",
@@ -15,6 +16,8 @@ app = FastAPI(
 # Init
 classifier = FileClassifier()
 hwp_converter = HwpOleFileConverter()
+pdf_converter = PdfFileConverter()
+
 init_db()
 
 # file classifier
@@ -120,6 +123,7 @@ async def test_ole_convert(
         "is_converted": document.is_converted,
     }
 
+
 # Search For Keyword
 @app.get("/test/search", tags=["test"])
 async def test_search(
@@ -158,3 +162,49 @@ async def test_search(
 #================================= DOC =================================
 
 #================================= PDF =================================
+#pdf로 변환하여 저장
+@app.post("/test/pdf_convert/{notice_id}", tags=["test"])
+async def test_pdf_convert(
+        notice_id: int,
+        db: Session = Depends(get_db),
+):
+    """
+    Method: Post
+    Description: DB에 저장된 PDF 바이너리를 읽어 텍스트로 변환 후 DB 업데이트
+    """
+    # 1. DB에서 파일 정보 조회
+    document = db.query(BidNotice).filter(BidNotice.id == notice_id).first()
+
+    if not document:
+        raise HTTPException(status_code=404, detail="Notice not found")
+    if not document.ntceSpecFileNm:
+        raise HTTPException(status_code=404, detail="File binary not found")
+
+    # 2. 파일 확장자 검증 (선택사항이지만 안전을 위해 권장)
+    if not document.ntceSpecFile.lower().endswith('.pdf'):
+        raise HTTPException(status_code=400, detail="This file is not a PDF")
+
+    # 3. PDF to TXT 변환
+    # DB의 LargeBinary(document.ntceSpecFileNm)를 그대로 넘깁니다.
+    text, success = pdf_converter.pdf_to_txt(document.ntceSpecFileNm)
+
+    print(f"[PDF Overview] {text[:100]}...")  # 로그 확인용
+
+    # 4. 결과 저장
+    if success:
+        document.converted_txt = text
+        document.is_converted = True
+    else:
+        # 실패 시 에러 메시지를 저장하거나 플래그만 False로 설정
+        document.is_converted = False
+        print(f"Conversion Failed: {text}")  # 실패 시 text변수에 에러메시지가 담김
+
+    db.commit()
+    db.refresh(document)
+
+    return {
+        "status": "success" if success else "failed",
+        "document_id": document.id,
+        "is_converted": document.is_converted,
+        "filename": document.ntceSpecFile
+    }


### PR DESCRIPTION
## 변경 사항
- demo/main.py 에 pdf to txt 모듈 추가 반영

## 변경 유형
- [ ] Chore
- [x] Feat
- [ ] BugFix
- [ ] Refactor
- [ ] Document

## Issue 번호
closed #17 

## 테스트 방법
```
//local terminal
uvicorn main:app --reload

//postman
      //upload
      Method: Post
      EndPoint: /test/upload
      Body: form-data
      key: file
      
      //convert
     Method: Post
     EndPoint: /test/pdf_convert/{notice_id}

```

## 테스트 결과
<!-- 이미지 삽입 -->
## pdf 파일 업로드
<img width="1497" height="659" alt="image" src="https://github.com/user-attachments/assets/8dea1345-f568-4f36-8023-b17a8a4c6e23" />

## pdf to txt 변환
<img width="1429" height="800" alt="image" src="https://github.com/user-attachments/assets/97fbd096-a4fd-4a1f-9a00-3248bee851d6" />
